### PR TITLE
Add basic product CRUD API

### DIFF
--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using back_tcc.Data;
+using back_tcc.Models;
+
+namespace back_tcc.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ProductsController(ApplicationDbContext context) : ControllerBase
+{
+    private readonly ApplicationDbContext _context = context;
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Product>>> GetProducts()
+        => await _context.Products.ToListAsync();
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<Product>> GetProduct(int id)
+    {
+        var product = await _context.Products.FindAsync(id);
+        return product is null ? NotFound() : product;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Product>> PostProduct(Product product)
+    {
+        _context.Products.Add(product);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> PutProduct(int id, Product product)
+    {
+        if (id != product.Id) return BadRequest();
+        _context.Entry(product).State = EntityState.Modified;
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteProduct(int id)
+    {
+        var product = await _context.Products.FindAsync(id);
+        if (product is null) return NotFound();
+        _context.Products.Remove(product);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+using back_tcc.Models;
+
+namespace back_tcc.Data;
+
+public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+    : DbContext(options)
+{
+    public DbSet<Product> Products => Set<Product>();
+}

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace back_tcc.Models;
+
+public enum ProductAvailability
+{
+    EmEstoque,
+    BaixoEstoque,
+    ForaDeEstoque
+}
+
+public class Product
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string Category { get; set; } = string.Empty;
+
+    [Range(0, double.MaxValue)]
+    public decimal Price { get; set; }
+
+    [Range(0, int.MaxValue)]
+    public int StockQuantity { get; set; }
+
+    public ProductAvailability Availability { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,13 @@
+using back_tcc.Data;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseInMemoryDatabase("RestaurantDb"));
+builder.Services.AddControllers();
 
 var app = builder.Build();
 
@@ -14,28 +19,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapControllers();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/back-tcc.csproj
+++ b/back-tcc.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- set up minimal ASP.NET Core API with in-memory database
- implement Product entity and controller for CRUD operations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acbff852808325b6b3844b7986b7bb